### PR TITLE
prov/gni:configury, add rpath for criterion

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -63,10 +63,10 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
 				AC_MSG_RESULT([yes])
 				gni_CPPFLAGS="-I$with_criterion/include $gni_CPPFLAGS"
 				if test -d "$with_criterion/lib"; then
-					gni_LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib $gni_LDFLAGS"
+				        gni_LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib -Wl,-rpath=$with_criterion/lib $gni_LDFLAGS"
 					have_criterion=true
 				elif test -d "$with_criterion/lib64"; then
-					gni_LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib64 $gni_LDFLAGS"
+					gni_LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib64 -Wl,-rpath=$with_criterion/lib64 $gni_LDFLAGS"
 					have_criterion=true
 				else
 					have_criterion=false


### PR DESCRIPTION
Add an rpath for criterion now that its using
shared libs.

@sungeunchoi 

add this to your new-criterion PR to avoid needing to set LD_LIBRARY_PATH
when running criterion test.

Signed-off-by: Howard Pritchard howardp@lanl.gov
